### PR TITLE
fix: include email in CashCtrl person contacts

### DIFF
--- a/app/services/billing_runner.rb
+++ b/app/services/billing_runner.rb
@@ -81,6 +81,8 @@ class BillingRunner
     # Only include non-cancelled items with valid artikel_nr
     billable_items = items.select { |i| i[:artikel_nr].present? }
 
+    invoice_description = billing_period_label(language).prepend('Parkgebühren ')
+
     cashctrl_invoice_id = @client.create_invoice(
       person_id: person_id,
       date: Date.today,
@@ -88,7 +90,8 @@ class BillingRunner
       items: billable_items.map do |i|
         { artikel_nr: i[:artikel_nr], name: i[:description], unit_price: i[:unit_price], quantity: 1 }
       end,
-      custom_fields: billing_period_custom_fields(language)
+      custom_fields: billing_period_custom_fields(language),
+      description: invoice_description
     )
 
     # Calculate total from reservations (CashCtrl has the prices)
@@ -158,13 +161,16 @@ class BillingRunner
       { artikel_nr: i[:artikel_nr], name: i[:description], unit_price: i[:unit_price], quantity: 1 }
     end
 
+    invoice_description = billing_period_label(language).prepend('Parkgebühren ')
+
     cashctrl_invoice_id = @client.create_invoice(
       person_id: person_id,
       date: Date.today,
       due_days: 30,
       items: cashctrl_items,
       custom_fields: billing_period_custom_fields(language),
-      account_id: cashctrl_account_id
+      account_id: cashctrl_account_id,
+      description: invoice_description
     )
 
     invoice = Invoice.create!(

--- a/app/services/cashctrl_client.rb
+++ b/app/services/cashctrl_client.rb
@@ -70,7 +70,8 @@ class CashctrlClient
     result = post('/person/create.json', {
                     firstName: first_name,
                     lastName: last_name,
-                    addresses: [address_data].to_json
+                    addresses: [address_data].to_json,
+                    contacts: [{ address: email, type: 'EMAIL_WORK' }].to_json
                   })
     result['insertId']
   end
@@ -103,7 +104,8 @@ class CashctrlClient
            id: user.cashctrl_person_id,
            firstName: user.first_name,
            lastName: user.last_name,
-           addresses: [address_data].to_json
+           addresses: [address_data].to_json,
+           contacts: [{ address: user.email, type: 'EMAIL_WORK' }].to_json
          })
   end
 

--- a/app/services/cashctrl_client.rb
+++ b/app/services/cashctrl_client.rb
@@ -110,7 +110,7 @@ class CashctrlClient
   end
 
   # Invoice methods
-  def create_invoice(person_id:, due_days:, date:, items:, custom_fields: {}, account_id: nil)
+  def create_invoice(person_id:, due_days:, date:, items:, custom_fields: {}, account_id: nil, description: nil)
     items_json = items.map do |item|
       if item[:type] == 'TEXT'
         { type: 'TEXT', name: item[:name] }
@@ -134,6 +134,7 @@ class CashctrlClient
       items: items_json.to_json
     }
     params[:accountId] = account_id if account_id
+    params[:description] = description if description
 
     # Add custom fields if provided
     if custom_fields.any?


### PR DESCRIPTION
New users created during billing runs didn't have email set in CashCtrl contacts (only in addresses). CashCtrl needs it in contacts to send invoice emails.