### PR TITLE
chore: upgrade Puma 7.2.0 and add EV charger legend (#10)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'sprockets-rails'
 gem 'pg', '1.6.3'
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem 'puma', '6.6.1'
+gem 'puma', '7.2.0'
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem 'importmap-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (6.6.1)
+    puma (7.2.0)
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
@@ -497,7 +497,7 @@ DEPENDENCIES
   omniauth-okta (= 2.0.0)
   omniauth-rails_csrf_protection (= 1.0.2)
   pg (= 1.6.3)
-  puma (= 6.6.1)
+  puma (= 7.2.0)
   pundit (= 2.5.2)
   rails (= 7.2.3)
   rails-controller-testing

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -137,6 +137,12 @@
           <span class="spectrum-Button-label">Reserve</span>
         </button>
       <% end %>
+      <p style="margin-top: 1rem; font-size: 13px; color: #6e6e6e;">
+        &#9889; = Parking spot with EV charger.
+        <a href="https://adobe.sharepoint.com/sites/BaselWorkplaceCommittee/SitePages/EV-Charging.aspx" target="_blank" class="spectrum-Link">
+          Learn how to use EV charging
+        </a>
+      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary

- Upgrade Puma 6.6.1 -> 7.2.0 for Heroku Router 2.0 compatibility
- Add EV charger legend with documentation link to reservation view (closes #10)

## Test plan
- [x] 270 tests passing
- [x] Verify lightning icon and legend visible on reservation page
- [x] Verify SharePoint link works